### PR TITLE
Update actions to ignore dataset/ folder

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           sparse-checkout: |
             /*
-            !dataset/*.parquet
+            !*.parquet
           sparse-checkout-cone-mode: false
       - uses: psf/black@stable
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           sparse-checkout: |
             /*
-            !dataset/*.parquet
+            !*.parquet
           sparse-checkout-cone-mode: false
 
       - name: Setup Python


### PR DESCRIPTION
If we look at [this ](https://github.com/rafaelpadilla/3W/actions/runs/18510893638/job/52751268917?pr=18) action job history we can see that it took almost 10 min to run. 

This happens because of the _actions/checkout_ action that will pull the **_dataset/_** directory, we should ignore that folder for the actions. 

- This PR updates actions/checkout to v4
- Remove the exclusion of a single file that does not exist anymore
- Enable the pipeline to run for every branch on both push and PR. 