### PR TITLE
`Closes PR#9`: Use pathlib.Path in place of os.path for modern path management.

### DIFF
--- a/tests/test_save_best_model.py
+++ b/tests/test_save_best_model.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import pickle
 import pytest
@@ -7,6 +6,7 @@ import torch.nn as nn
 import sklearn.linear_model
 
 from io import BytesIO
+from pathlib import Path
 
 from ThreeWToolkit.utils import ModelRecorder
 
@@ -34,9 +34,9 @@ class TestModelRecorder:
         """
         with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as tmp:
             ModelRecorder.save_best_model(self.torch_model, tmp.name)
-            assert os.path.exists(tmp.name)
-            assert os.path.getsize(tmp.name) > 0
-        os.remove(tmp.name)
+            assert Path(tmp.name).exists()
+            assert Path(tmp.name).stat().st_size > 0
+        Path(tmp.name).unlink()
 
     def test_save_sklearn_model(self):
         """
@@ -44,11 +44,11 @@ class TestModelRecorder:
         """
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as tmp:
             ModelRecorder.save_best_model(self.sklearn_model, tmp.name)
-            assert os.path.exists(tmp.name)
+            assert Path(tmp.name).exists()
             with open(tmp.name, "rb") as f:
                 loaded = pickle.load(f)
                 assert isinstance(loaded, sklearn.linear_model.LogisticRegression)
-        os.remove(tmp.name)
+        Path(tmp.name).unlink()
 
     def test_save_invalid_extension(self):
         """
@@ -93,7 +93,7 @@ class TestModelRecorder:
         with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as tmp:
             with pytest.raises(RuntimeError, match="Error saving PyTorch model"):
                 ModelRecorder.save_best_model(self.torch_model, tmp.name)
-        os.remove(tmp.name)
+        Path(tmp.name).unlink()
 
     def test_exception_inside_pickle_block(self, monkeypatch):
         """
@@ -108,4 +108,4 @@ class TestModelRecorder:
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as tmp:
             with pytest.raises(RuntimeError, match="Error saving Pickle model"):
                 ModelRecorder.save_best_model(self.sklearn_model, tmp.name)
-        os.remove(tmp.name)
+        Path(tmp.name).unlink()

--- a/tests/test_trainer_logger.py
+++ b/tests/test_trainer_logger.py
@@ -1,8 +1,8 @@
-import os
 import json
 import pickle
 import shutil
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -24,7 +24,7 @@ def sample_log():
 def temp_log_dir():
     """Create and clean up a temporary directory for log files."""
     log_dir = "temp_test_logs"
-    os.makedirs(log_dir, exist_ok=True)
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
     yield log_dir
     shutil.rmtree(log_dir)
 
@@ -34,8 +34,8 @@ def test_log_json_format(sample_log, temp_log_dir):
     path = TrainerLogger.log_optimization_progress(
         sample_log, log_dir=temp_log_dir, file_format="json"
     )
-    assert os.path.exists(path)
-    assert path.endswith(".json")
+    assert Path(path).exists()
+    assert Path(path).suffix == ".json"
 
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
@@ -48,8 +48,8 @@ def test_log_pickle_format(sample_log, temp_log_dir):
     path = TrainerLogger.log_optimization_progress(
         sample_log, log_dir=temp_log_dir, file_format="pickle"
     )
-    assert os.path.exists(path)
-    assert path.endswith(".pkl")
+    assert Path(path).exists()
+    assert Path(path).suffix == ".pkl"
 
     with open(path, "rb") as f:
         data = pickle.load(f)

--- a/toolkit/ThreeWToolkit/data_loader/csv_data_loader.py
+++ b/toolkit/ThreeWToolkit/data_loader/csv_data_loader.py
@@ -1,5 +1,5 @@
-import os
 import pandas as pd
+from pathlib import Path
 
 
 def load_csv(
@@ -17,7 +17,7 @@ def load_csv(
     Returns:
         pd.DataFrame: The loaded DataFrame with selected columns.
     """
-    if not os.path.isfile(file_path):
+    if not Path(file_path).is_file():
         raise FileNotFoundError(f"The file '{file_path}' does not exist.")
 
     if not isinstance(column_names, list) or not all(

--- a/toolkit/ThreeWToolkit/utils/model_recorder.py
+++ b/toolkit/ThreeWToolkit/utils/model_recorder.py
@@ -1,11 +1,10 @@
-import os
 from pathlib import Path
 from typing import IO, Any
 
 
 class ModelRecorder:
     @staticmethod
-    def save_best_model(model: Any, filename: str | os.PathLike | IO[bytes]) -> None:
+    def save_best_model(model: Any, filename: str | Path | IO[bytes]) -> None:
         """
         Save a model to disk depending on its type and file extension.
         Supports PyTorch and scikit-learn (Pickle).
@@ -14,7 +13,7 @@ class ModelRecorder:
             model: Trained model object.
             filename: File name or file-like object where the model will be saved.
         """
-        if isinstance(filename, (str, os.PathLike)):
+        if isinstance(filename, (str, Path)):
             path = Path(filename)
             ext = path.suffix.lower()
         elif hasattr(filename, "write"):
@@ -49,16 +48,16 @@ class ModelRecorder:
             raise ValueError(f"Unsupported file extension: {ext}")
 
     @staticmethod
-    def load_model(filename: str | os.PathLike | IO[bytes], model: Any = None) -> Any:
+    def load_model(filename: str | Path | IO[bytes], model: Any = None) -> Any:
         """
         Load a model from disk depending on its type and file extension.
         Supports PyTorch (.pt, .pth) and scikit-learn/Pickle (.pkl, .pickle).
 
         Parameters:
-            filename (str | os.PathLike | IO[bytes]):  Path or file-like object pointing to the saved model file.
+            filename (str | Path | IO[bytes]):  Path or file-like object pointing to the saved model file.
             model (Any, optional):  An uninitialized model instance to load weights into. Required for PyTorch models.
         """
-        if isinstance(filename, (str, os.PathLike)):
+        if isinstance(filename, (str, Path)):
             path = Path(filename)
             ext = path.suffix.lower()
         elif hasattr(filename, "read"):

--- a/toolkit/ThreeWToolkit/utils/trainer_logger.py
+++ b/toolkit/ThreeWToolkit/utils/trainer_logger.py
@@ -1,4 +1,3 @@
-import os
 import json
 import pickle
 import logging
@@ -63,12 +62,13 @@ class TrainerLogger:
         if not progress_log:
             raise ValueError("progress_log must be a non-empty dictionary")
 
-        os.makedirs(log_dir, exist_ok=True)
+        log_dir_path = Path(log_dir)
+        log_dir_path.mkdir(parents=True, exist_ok=True)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         extension = ".json" if file_format == "json" else ".pkl"
         filename = f"log_{timestamp}{extension}"
-        file_path = os.path.join(log_dir, filename)
+        file_path = log_dir_path / filename
 
         try:
             if file_format == "json":
@@ -83,4 +83,4 @@ class TrainerLogger:
             logger.error("Failed to save optimization progress: %s", e)
             raise
 
-        return file_path
+        return str(file_path)


### PR DESCRIPTION
All occurrences of `os.path` have been replaced with `pathlib.Path`, to provide a modern, object oriented interface.

Please review and provide feedback if any further adjustments are needed.

Closes #9 