### PR TITLE
Add exceptions for HTML report files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ __pycache__/
 html/
 *.html
 
+# Overrides
+!toolkit/ThreeWToolkit/reports/html/
+!toolkit/ThreeWToolkit/reports/html/**
+
 # VS Code configuration
 .vscode/
 


### PR DESCRIPTION
This PR addresses Issue #26 by adding a negation rule to .gitignore.

Previously, the global html/ ignore rule was preventing the version-controlled toolkit/ThreeWToolkit/reports/html directory from being tracked. This fix adds a specific override for the reports folder while maintaining the general exclusion of HTML files throughout the rest of the toolkit.

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
