### PR TITLE
refactor: remove unnecessary getattr for is_windowed in feature extra…

### DIFF
--- a/tests/test_extract_exponential_statistical_features.py
+++ b/tests/test_extract_exponential_statistical_features.py
@@ -32,7 +32,6 @@ class EWStatisticalConfig:
         eps=1e-10,
         decay=0.9,
         selected_features=None,
-        is_windowed=True,
         label_column="label",
     ):
         if overlap < 0 or overlap >= 1:
@@ -55,7 +54,6 @@ class EWStatisticalConfig:
             if selected_features is not None
             else self.DEFAULT_FEATURES
         )
-        self.is_windowed = is_windowed
         self.label_column = label_column
 
 
@@ -107,8 +105,9 @@ class TestExtractEWStatisticalFeatures:
 
     def test_basic_extraction_all_features(self, windowed_data_with_labels):
         """Tests basic extraction with all default features."""
-        config = EWStatisticalConfig(is_windowed=True, window_size=4)
+        config = EWStatisticalConfig(window_size=4)
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -140,9 +139,10 @@ class TestExtractEWStatisticalFeatures:
     def test_ew_mean_calculation(self, windowed_data_with_labels):
         """Tests that exponentially weighted mean is calculated correctly."""
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_mean"]
+            window_size=4, decay=0.9, selected_features=["ew_mean"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -158,9 +158,10 @@ class TestExtractEWStatisticalFeatures:
     def test_ew_std_calculation(self, windowed_data_with_labels):
         """Tests exponentially weighted standard deviation."""
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_std"]
+            window_size=4, decay=0.9, selected_features=["ew_std"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -179,9 +180,10 @@ class TestExtractEWStatisticalFeatures:
         df = pd.DataFrame(data)
 
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_skew"]
+            window_size=4, decay=0.9, selected_features=["ew_skew"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(df)
 
@@ -200,9 +202,10 @@ class TestExtractEWStatisticalFeatures:
         df = pd.DataFrame(data)
 
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_kurt"]
+            window_size=4, decay=0.9, selected_features=["ew_kurt"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(df)
 
@@ -212,12 +215,12 @@ class TestExtractEWStatisticalFeatures:
     def test_ew_quantiles_calculation(self, windowed_data_with_labels):
         """Tests exponentially weighted quantile calculations."""
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             selected_features=["ew_min", "ew_1qrt", "ew_med", "ew_3qrt", "ew_max"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -238,12 +241,12 @@ class TestExtractEWStatisticalFeatures:
     def test_constant_values_handling(self, constant_value_data):
         """Tests handling of constant values (zero std)."""
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             selected_features=["ew_mean", "ew_std", "ew_skew", "ew_kurt"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(constant_value_data)
 
@@ -260,12 +263,12 @@ class TestExtractEWStatisticalFeatures:
     def test_multivariate_extraction(self, multivariate_windowed_data):
         """Tests feature extraction for multivariate data."""
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             selected_features=["ew_mean", "ew_std"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(multivariate_windowed_data)
 
@@ -282,9 +285,10 @@ class TestExtractEWStatisticalFeatures:
         """Tests that only selected features are computed."""
         selected = ["ew_mean", "ew_max"]
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=selected
+            window_size=4, decay=0.9, selected_features=selected
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -298,16 +302,18 @@ class TestExtractEWStatisticalFeatures:
         """Tests that different decay values produce different results."""
         # High decay (more uniform weights)
         config_high = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.95, selected_features=["ew_mean"]
+            window_size=4, decay=0.95, selected_features=["ew_mean"]
         )
         extractor_high = ExtractEWStatisticalFeatures(config_high)
+        extractor_high.is_windowed = True
         result_high = extractor_high(windowed_data_with_labels)
 
         # Low decay (more weight concentrated on recent values)
         config_low = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.5, selected_features=["ew_mean"]
+            window_size=4, decay=0.5, selected_features=["ew_mean"]
         )
         extractor_low = ExtractEWStatisticalFeatures(config_low)
+        extractor_low.is_windowed = True
         result_low = extractor_low(windowed_data_with_labels)
 
         # For increasing sequence [1,2,3,4], lower decay concentrates more weight
@@ -318,13 +324,13 @@ class TestExtractEWStatisticalFeatures:
         """Tests that offset correctly skips initial windows."""
         offset = 2
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             offset=offset,
             selected_features=["ew_mean"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -347,8 +353,9 @@ class TestExtractEWStatisticalFeatures:
             }
         )
 
-        config = EWStatisticalConfig(is_windowed=False, window_size=4)
+        config = EWStatisticalConfig(window_size=4)
         extractor = ExtractEWStatisticalFeatures(config)
+        # is_windowed defaults to False, so no need to set it
 
         with pytest.raises(ValueError, match="Data is not windowed"):
             extractor(data)
@@ -372,8 +379,9 @@ class TestExtractEWStatisticalFeatures:
 
     def test_empty_data_raises_error(self):
         """Tests that empty DataFrame raises appropriate error."""
-        config = EWStatisticalConfig(is_windowed=True, window_size=4)
+        config = EWStatisticalConfig(window_size=4)
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         empty_df = pd.DataFrame()
 
@@ -382,8 +390,9 @@ class TestExtractEWStatisticalFeatures:
 
     def test_no_variables_found_raises_error(self):
         """Tests error when no valid variable columns are found."""
-        config = EWStatisticalConfig(is_windowed=True, window_size=4)
+        config = EWStatisticalConfig(window_size=4)
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         invalid_data = pd.DataFrame(
             {"col1": [1, 2, 3], "col2": [4, 5, 6], "label": [100, 101, 102]}
@@ -394,8 +403,9 @@ class TestExtractEWStatisticalFeatures:
 
     def test_offset_exceeds_data_length(self, windowed_data_with_labels):
         """Tests that offset larger than data raises error."""
-        config = EWStatisticalConfig(is_windowed=True, window_size=4, offset=100)
+        config = EWStatisticalConfig(window_size=4, offset=100)
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(ValueError, match="Offset .* is larger than data length"):
             extractor(windowed_data_with_labels)
@@ -412,12 +422,12 @@ class TestExtractEWStatisticalFeatures:
         )
 
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             label_column=None,
             selected_features=["ew_mean"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -427,8 +437,9 @@ class TestExtractEWStatisticalFeatures:
 
     def test_type_error_on_non_dataframe_input(self):
         """Tests that non-DataFrame input raises TypeError."""
-        config = EWStatisticalConfig(is_windowed=True, window_size=4)
+        config = EWStatisticalConfig(window_size=4)
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(TypeError, match="Input data must be a pandas DataFrame"):
             extractor([1, 2, 3, 4])
@@ -436,9 +447,10 @@ class TestExtractEWStatisticalFeatures:
     def test_nan_handling_warning(self, windowed_data_with_labels):
         """Tests that NaN values are handled."""
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_mean"]
+            window_size=4, decay=0.9, selected_features=["ew_mean"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         # Introduce NaN
         data_with_nan = windowed_data_with_labels.copy()
@@ -463,9 +475,10 @@ class TestExtractEWStatisticalFeatures:
         )
 
         config = EWStatisticalConfig(
-            is_windowed=True, window_size=4, decay=0.9, selected_features=["ew_max"]
+            window_size=4, decay=0.9, selected_features=["ew_max"]
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -485,12 +498,12 @@ class TestExtractEWStatisticalFeatures:
         )
 
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             selected_features=["ew_mean", "ew_std"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -509,13 +522,13 @@ class TestExtractEWStatisticalFeatures:
         )
 
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             eps=1e-10,
             selected_features=["ew_skew", "ew_kurt"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -541,12 +554,12 @@ class TestExtractEWStatisticalFeatures:
     def test_feature_ordering_consistency(self, multivariate_windowed_data):
         """Tests that feature ordering is consistent across variables."""
         config = EWStatisticalConfig(
-            is_windowed=True,
             window_size=4,
             decay=0.9,
             selected_features=["ew_mean", "ew_std", "ew_max"],
         )
         extractor = ExtractEWStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(multivariate_windowed_data)
 

--- a/tests/test_extract_statistical_features.py
+++ b/tests/test_extract_statistical_features.py
@@ -28,7 +28,6 @@ class StatisticalConfig:
             "max",
         ],
         multivariate=True,
-        is_windowed=True,
         label_column="label",
     ):
         if overlap < 0 or overlap >= 1:
@@ -44,7 +43,6 @@ class StatisticalConfig:
         self.eps = eps
         self.selected_features = selected_features
         self.multivariate = multivariate
-        self.is_windowed = is_windowed
         self.label_column = label_column
 
 
@@ -99,8 +97,9 @@ class TestExtractStatisticalFeatures:
 
     def test_basic_extraction_all_features(self, windowed_data_with_labels):
         """Tests basic extraction with all default features."""
-        config = StatisticalConfig(is_windowed=True)
+        config = StatisticalConfig()
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -131,8 +130,9 @@ class TestExtractStatisticalFeatures:
 
     def test_mean_calculation(self, windowed_data_with_labels):
         """Tests that mean is calculated correctly."""
-        config = StatisticalConfig(is_windowed=True, selected_features=["mean"])
+        config = StatisticalConfig(selected_features=["mean"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -144,8 +144,9 @@ class TestExtractStatisticalFeatures:
 
     def test_std_calculation(self, windowed_data_with_labels):
         """Tests that standard deviation is calculated correctly."""
-        config = StatisticalConfig(is_windowed=True, selected_features=["std"])
+        config = StatisticalConfig(selected_features=["std"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -156,9 +157,10 @@ class TestExtractStatisticalFeatures:
     def test_quantiles_calculation(self, windowed_data_with_labels):
         """Tests quantile calculations (min, quartiles, median, max)."""
         config = StatisticalConfig(
-            is_windowed=True, selected_features=["min", "1qrt", "med", "3qrt", "max"]
+            selected_features=["min", "1qrt", "med", "3qrt", "max"]
         )
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -180,8 +182,9 @@ class TestExtractStatisticalFeatures:
         }
         df = pd.DataFrame(data)
 
-        config = StatisticalConfig(is_windowed=True, selected_features=["skew"])
+        config = StatisticalConfig(selected_features=["skew"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(df)
 
@@ -199,8 +202,9 @@ class TestExtractStatisticalFeatures:
         }
         df = pd.DataFrame(data)
 
-        config = StatisticalConfig(is_windowed=True, selected_features=["kurt"])
+        config = StatisticalConfig(selected_features=["kurt"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(df)
 
@@ -210,10 +214,9 @@ class TestExtractStatisticalFeatures:
 
     def test_constant_values_handling(self, constant_value_data):
         """Tests handling of constant values (zero std)."""
-        config = StatisticalConfig(
-            is_windowed=True, selected_features=["mean", "std", "skew", "kurt"]
-        )
+        config = StatisticalConfig(selected_features=["mean", "std", "skew", "kurt"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(constant_value_data)
 
@@ -229,8 +232,9 @@ class TestExtractStatisticalFeatures:
 
     def test_multivariate_extraction(self, multivariate_windowed_data):
         """Tests feature extraction for multivariate data."""
-        config = StatisticalConfig(is_windowed=True, selected_features=["mean", "std"])
+        config = StatisticalConfig(selected_features=["mean", "std"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(multivariate_windowed_data)
 
@@ -246,8 +250,9 @@ class TestExtractStatisticalFeatures:
     def test_selected_features_subset(self, windowed_data_with_labels):
         """Tests that only selected features are computed."""
         selected = ["mean", "max"]
-        config = StatisticalConfig(is_windowed=True, selected_features=selected)
+        config = StatisticalConfig(selected_features=selected)
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -261,10 +266,9 @@ class TestExtractStatisticalFeatures:
     def test_offset_application(self, windowed_data_with_labels):
         """Tests that offset correctly skips initial windows."""
         offset = 2
-        config = StatisticalConfig(
-            is_windowed=True, offset=offset, selected_features=["mean"]
-        )
+        config = StatisticalConfig(offset=offset, selected_features=["mean"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -290,7 +294,7 @@ class TestExtractStatisticalFeatures:
             }
         )
 
-        config = StatisticalConfig(is_windowed=False)
+        config = StatisticalConfig()
         extractor = ExtractStatisticalFeatures(config)
 
         with pytest.raises(ValueError, match="Data is not windowed"):
@@ -309,8 +313,9 @@ class TestExtractStatisticalFeatures:
 
     def test_empty_data_raises_error(self):
         """Tests that empty DataFrame raises appropriate error."""
-        config = StatisticalConfig(is_windowed=True)
+        config = StatisticalConfig()
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         empty_df = pd.DataFrame()
 
@@ -319,8 +324,9 @@ class TestExtractStatisticalFeatures:
 
     def test_no_variables_found_raises_error(self):
         """Tests error when no valid variable columns are found."""
-        config = StatisticalConfig(is_windowed=True)
+        config = StatisticalConfig()
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         # DataFrame with wrong column format
         invalid_data = pd.DataFrame(
@@ -333,10 +339,10 @@ class TestExtractStatisticalFeatures:
     def test_offset_exceeds_data_length(self, windowed_data_with_labels):
         """Tests that offset larger than data raises error."""
         config = StatisticalConfig(
-            is_windowed=True,
             offset=100,  # Much larger than data
         )
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(ValueError, match="Offset .* is larger than data length"):
             extractor(windowed_data_with_labels)
@@ -352,10 +358,9 @@ class TestExtractStatisticalFeatures:
             }
         )
 
-        config = StatisticalConfig(
-            is_windowed=True, label_column=None, selected_features=["mean"]
-        )
+        config = StatisticalConfig(label_column=None, selected_features=["mean"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -365,16 +370,18 @@ class TestExtractStatisticalFeatures:
 
     def test_type_error_on_non_dataframe_input(self):
         """Tests that non-DataFrame input raises TypeError."""
-        config = StatisticalConfig(is_windowed=True)
+        config = StatisticalConfig()
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(TypeError, match="Input data must be a pandas DataFrame"):
             extractor([1, 2, 3, 4])  # List instead of DataFrame
 
     def test_nan_handling_warning(self, windowed_data_with_labels):
         """Tests that NaN values are handled and warning is shown."""
-        config = StatisticalConfig(is_windowed=True, selected_features=["mean"])
+        config = StatisticalConfig(selected_features=["mean"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         # Introduce NaN
         data_with_nan = windowed_data_with_labels.copy()
@@ -398,8 +405,9 @@ class TestExtractStatisticalFeatures:
             }
         )
 
-        config = StatisticalConfig(is_windowed=True, selected_features=["max"])
+        config = StatisticalConfig(selected_features=["max"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -419,8 +427,9 @@ class TestExtractStatisticalFeatures:
             }
         )
 
-        config = StatisticalConfig(is_windowed=True, selected_features=["mean", "std"])
+        config = StatisticalConfig(selected_features=["mean", "std"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -429,10 +438,9 @@ class TestExtractStatisticalFeatures:
 
     def test_feature_ordering_consistency(self, multivariate_windowed_data):
         """Tests that feature ordering is consistent across variables."""
-        config = StatisticalConfig(
-            is_windowed=True, selected_features=["mean", "std", "max"]
-        )
+        config = StatisticalConfig(selected_features=["mean", "std", "max"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(multivariate_windowed_data)
 
@@ -461,11 +469,11 @@ class TestExtractStatisticalFeatures:
 
         # With large eps, should return 0 for skew/kurt
         config_large_eps = StatisticalConfig(
-            is_windowed=True,
             selected_features=["skew", "kurt"],
             eps=1.0,  # Large eps
         )
         extractor_large = ExtractStatisticalFeatures(config_large_eps)
+        extractor_large.is_windowed = True
         result_large = extractor_large(data)
 
         assert result_large["var1_skew"].iloc[0] == 0.0
@@ -502,8 +510,9 @@ class TestExtractStatisticalFeatures:
             }
         )
 
-        config = StatisticalConfig(is_windowed=True, selected_features=["mean", "std"])
+        config = StatisticalConfig(selected_features=["mean", "std"])
         extractor = ExtractStatisticalFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 

--- a/tests/test_extract_wavelet_features.py
+++ b/tests/test_extract_wavelet_features.py
@@ -16,7 +16,6 @@ class WaveletConfig:
         overlap=0.0,
         offset=0,
         wavelet="db1",
-        is_windowed=True,
         label_column="label",
     ):
         if overlap < 0 or overlap >= 1:
@@ -30,7 +29,6 @@ class WaveletConfig:
         self.overlap = overlap
         self.offset = offset
         self.wavelet = wavelet
-        self.is_windowed = is_windowed
         self.label_column = label_column
 
 
@@ -81,8 +79,9 @@ class TestExtractWaveletFeatures:
 
     def test_basic_extraction_univariate(self, windowed_data_with_labels):
         """Tests basic wavelet feature extraction for univariate data."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -105,8 +104,9 @@ class TestExtractWaveletFeatures:
 
     def test_multivariate_extraction(self, multivariate_windowed_data):
         """Tests wavelet feature extraction for multivariate data."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(multivariate_windowed_data)
 
@@ -121,8 +121,9 @@ class TestExtractWaveletFeatures:
     def test_offset_application(self, windowed_data_with_labels):
         """Tests that offset parameter correctly skips initial windows."""
         offset = 2
-        config = WaveletConfig(level=2, offset=offset, is_windowed=True)
+        config = WaveletConfig(level=2, offset=offset)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -145,7 +146,7 @@ class TestExtractWaveletFeatures:
             }
         )
 
-        config = WaveletConfig(level=2, is_windowed=False)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
 
         with pytest.raises(ValueError, match="Data is not windowed"):
@@ -165,8 +166,9 @@ class TestExtractWaveletFeatures:
 
     def test_output_column_names_format(self, windowed_data_with_labels):
         """Tests that output columns follow the expected naming convention."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(windowed_data_with_labels)
 
@@ -178,8 +180,9 @@ class TestExtractWaveletFeatures:
 
     def test_empty_data_raises_error(self):
         """Tests that empty DataFrame raises appropriate error."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         empty_df = pd.DataFrame()
 
@@ -188,8 +191,9 @@ class TestExtractWaveletFeatures:
 
     def test_no_variables_found_raises_error(self):
         """Tests error when no valid variable columns are found."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         # DataFrame with wrong column format
         invalid_data = pd.DataFrame(
@@ -201,8 +205,9 @@ class TestExtractWaveletFeatures:
 
     def test_window_size_mismatch_handling(self):
         """Tests handling of windows with incorrect size."""
-        config = WaveletConfig(level=2, is_windowed=True)  # Expects window_size=4
+        config = WaveletConfig(level=2)  # Expects window_size=4
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         # Create data with wrong window size (only 3 columns)
         data = pd.DataFrame(
@@ -219,17 +224,18 @@ class TestExtractWaveletFeatures:
         config = WaveletConfig(
             level=2,
             offset=100,  # Much larger than data
-            is_windowed=True,
         )
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(ValueError, match="Offset .* is larger than data length"):
             extractor(windowed_data_with_labels)
 
     def test_nan_handling_warning(self, windowed_data_with_labels):
         """Tests that NaN values trigger a warning."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         # Introduce NaN
         data_with_nan = windowed_data_with_labels.copy()
@@ -241,8 +247,9 @@ class TestExtractWaveletFeatures:
 
     def test_feature_names_generation(self):
         """Tests that feature names are correctly generated for different levels."""
-        config = WaveletConfig(level=3, is_windowed=True)
+        config = WaveletConfig(level=3)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         expected_names = ["A3", "D3", "A2", "D2", "A1", "D1", "A0"]
         assert extractor.feat_names == expected_names
@@ -250,8 +257,9 @@ class TestExtractWaveletFeatures:
     def test_different_wavelet_types(self, windowed_data_with_labels):
         """Tests that different wavelet types work correctly."""
         for wavelet in ["db1", "db2", "sym2", "coif1"]:
-            config = WaveletConfig(level=2, wavelet=wavelet, is_windowed=True)
+            config = WaveletConfig(level=2, wavelet=wavelet)
             extractor = ExtractWaveletFeatures(config)
+            extractor.is_windowed = True
 
             result = extractor(windowed_data_with_labels)
             assert not result.empty
@@ -268,8 +276,9 @@ class TestExtractWaveletFeatures:
             }
         )
 
-        config = WaveletConfig(level=2, is_windowed=True, label_column=None)
+        config = WaveletConfig(level=2, label_column=None)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         result = extractor(data)
 
@@ -279,8 +288,9 @@ class TestExtractWaveletFeatures:
 
     def test_type_error_on_non_dataframe_input(self):
         """Tests that non-DataFrame input raises TypeError."""
-        config = WaveletConfig(level=2, is_windowed=True)
+        config = WaveletConfig(level=2)
         extractor = ExtractWaveletFeatures(config)
+        extractor.is_windowed = True
 
         with pytest.raises(TypeError, match="Input data must be a pandas DataFrame"):
             extractor([1, 2, 3, 4])  # List instead of DataFrame

--- a/toolkit/ThreeWToolkit/feature_extraction/extract_exponential_statistics_features.py
+++ b/toolkit/ThreeWToolkit/feature_extraction/extract_exponential_statistics_features.py
@@ -51,7 +51,7 @@ class ExtractEWStatisticalFeatures(BaseStep):
         self.selected_features = (
             config.selected_features if config.selected_features else self.FEATURES
         )
-        self.is_windowed = getattr(config, "is_windowed", False)
+        self.is_windowed = False
         self.label_column = getattr(config, "label_column", None)
 
     def _initialize_weights(self):
@@ -285,7 +285,7 @@ class ExtractEWStatisticalFeatures(BaseStep):
         if not self.is_windowed:
             raise ValueError(
                 "Data is not windowed. Please use the Windowing class to window your data first, "
-                "then set is_windowed=True in the config when initializing ExtractEWStatisticalFeatures."
+                "then set extractor.is_windowed = True on the ExtractEWStatisticalFeatures instance."
             )
 
         # Identify variables

--- a/toolkit/ThreeWToolkit/feature_extraction/extract_statistical_features.py
+++ b/toolkit/ThreeWToolkit/feature_extraction/extract_statistical_features.py
@@ -41,7 +41,7 @@ class ExtractStatisticalFeatures(BaseStep):
             config.selected_features if config.selected_features else self.FEATURES
         )
         self.multivariate = getattr(config, "multivariate", True)
-        self.is_windowed = getattr(config, "is_windowed", False)
+        self.is_windowed = False
         self.label_column = getattr(config, "label_column", None)
 
     def _identify_variables(self, data: pd.DataFrame) -> dict:
@@ -227,7 +227,7 @@ class ExtractStatisticalFeatures(BaseStep):
         if not self.is_windowed:
             raise ValueError(
                 "Data is not windowed. Please use the Windowing class to window your data first, "
-                "then set is_windowed=True in the config when initializing ExtractStatisticalFeatures."
+                "then set extractor.is_windowed = True on the ExtractStatisticalFeatures instance."
             )
 
         # Identify variables

--- a/toolkit/ThreeWToolkit/feature_extraction/extract_wavelet_features.py
+++ b/toolkit/ThreeWToolkit/feature_extraction/extract_wavelet_features.py
@@ -37,7 +37,7 @@ class ExtractWaveletFeatures(BaseStep):
         self.offset = config.offset
         self.wavelet = config.wavelet
 
-        self.is_windowed = getattr(config, "is_windowed", False)
+        self.is_windowed = False
         self.label_column = getattr(config, "label_column", None)
 
         # Initialize wavelet filter matrix
@@ -239,7 +239,7 @@ class ExtractWaveletFeatures(BaseStep):
         if not self.is_windowed:
             raise ValueError(
                 "Data is not windowed. Please use the Windowing class to window your data first, "
-                "then set is_windowed=True in the config when initializing ExtractWaveletFeatures."
+                "then set extractor.is_windowed = True on the ExtractWaveletFeatures instance."
             )
 
         # Identify variables


### PR DESCRIPTION

Removing unnecessary `getattr(config, "is_windowed", False)` from feature extraction classes and updates tests to set `is_windowed` directly on extracttor instances.

## Changes

- **Feature extraction classes** (`ExtractStatisticalFeatures`, `ExtractEWStatisticalFeatures`, `ExtractWaveletFeatures`):
  - Removed `getattr(config, "is_windowed", False)` 
  - Changed to `self.is_windowed = False` (as default value)
  - Updated error messages to reference setting `extractor.is_windowed = True` on the instance

- **Test files**:
  - Removed `is_windowed=True/False` from all config instantiations
  - Added `extractor.is_windowed = True` after extractor instantiation (where needed)
  - Removed `is_windowed` parameter from mock config class `__init__` methods

## Why This Change Is Needed

:warning:  This is my point of view of how our code should work. Please, let me know if this needs to be adjusted!!!

1. The real config classes (`StatisticalConfig`, `EWStatisticalConfig`, `WaveletConfig`) don't have an `is_windowed` attribute, so using `getattr` with a default seems not correct.

2. The code already defines `is_windowed`:
   - `Pipeline` sets it directly: `step.is_windowed = True` (line 494)
   - Notebooks show: `extractor.is_windowed = True`

3. These changes makes it explicit that `is_windowed` is an instance attribute, not a config parameter. - Is this the expetced behavior?

## Testing

 ✅   All tests were adjusted and pass:
- `test_extract_statistical_features.py`: 
- `test_extract_exponential_statistical_features.py`:
- `test_extract_wavelet_features.py`: 

-------------------------

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
