### PR TITLE
Mathparracho/logger_update

### DIFF
--- a/toolkit/ThreeWToolkit/constants.py
+++ b/toolkit/ThreeWToolkit/constants.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from importlib import resources
+from datetime import datetime
 
 package = "ThreeWToolkit"
 # We define the project root as the directory where the toolkit is installed (i.e. the parent directory of ThreeWToolkit).
@@ -12,6 +13,11 @@ REPORTS_DIR = OUTPUT_DIR / "reports"  # Directory for generated PDFs
 
 # Define the path to the mock visualization objects plot folder
 PLOTS_DIR = OUTPUT_DIR / "3w_plots"
+
+LOGS_DIR = OUTPUT_DIR / "logs"
+from .logging_config import setup_default_logging
+_run_id = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+setup_default_logging(LOGS_DIR, run_id=_run_id)
 
 # Define the path to the LaTeX and HTML template documents directory
 REPORTS_DIR = PROJECT_ROOT / package / "reports"

--- a/toolkit/ThreeWToolkit/constants.py
+++ b/toolkit/ThreeWToolkit/constants.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from importlib import resources
 from datetime import datetime
+from .logging_config import setup_default_logging
 
 package = "ThreeWToolkit"
 # We define the project root as the directory where the toolkit is installed (i.e. the parent directory of ThreeWToolkit).
@@ -15,7 +16,6 @@ REPORTS_DIR = OUTPUT_DIR / "reports"  # Directory for generated PDFs
 PLOTS_DIR = OUTPUT_DIR / "3w_plots"
 
 LOGS_DIR = OUTPUT_DIR / "logs"
-from .logging_config import setup_default_logging
 _run_id = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 setup_default_logging(LOGS_DIR, run_id=_run_id)
 

--- a/toolkit/ThreeWToolkit/logging_config.py
+++ b/toolkit/ThreeWToolkit/logging_config.py
@@ -1,19 +1,28 @@
 # ThreeWToolkit/logging_config.py
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
-def setup_default_logging(logs_dir: Path, run_id: str, level: int = logging.INFO) -> Path:
-    root = logging.getLogger()
+_CONFIGURED: bool = False
+_LOG_FILE: Path | None = None
 
-    if getattr(root, "_threew_configured", False):
-        return Path(getattr(root, "_threew_log_file"))
+
+def setup_default_logging(
+    logs_dir: Path, run_id: str, level: int = logging.INFO
+) -> Path:
+    global _CONFIGURED, _LOG_FILE
+
+    if _CONFIGURED and _LOG_FILE is not None:
+        return _LOG_FILE
 
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_file = logs_dir / f"run_{run_id}.log"
 
     fmt = logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
 
+    root = logging.getLogger()
     root.setLevel(level)
 
     fh = RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=3)
@@ -25,6 +34,6 @@ def setup_default_logging(logs_dir: Path, run_id: str, level: int = logging.INFO
     root.addHandler(sh)
     root.addHandler(fh)
 
-    root._threew_configured = True
-    root._threew_log_file = str(log_file)
+    _CONFIGURED = True
+    _LOG_FILE = log_file
     return log_file

--- a/toolkit/ThreeWToolkit/logging_config.py
+++ b/toolkit/ThreeWToolkit/logging_config.py
@@ -1,0 +1,30 @@
+# ThreeWToolkit/logging_config.py
+import logging
+from pathlib import Path
+from logging.handlers import RotatingFileHandler
+
+def setup_default_logging(logs_dir: Path, run_id: str, level: int = logging.INFO) -> Path:
+    root = logging.getLogger()
+
+    if getattr(root, "_threew_configured", False):
+        return Path(getattr(root, "_threew_log_file"))
+
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / f"run_{run_id}.log"
+
+    fmt = logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
+
+    root.setLevel(level)
+
+    fh = RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=3)
+    fh.setFormatter(fmt)
+
+    sh = logging.StreamHandler()
+    sh.setFormatter(fmt)
+
+    root.addHandler(sh)
+    root.addHandler(fh)
+
+    root._threew_configured = True
+    root._threew_log_file = str(log_file)
+    return log_file

--- a/toolkit/ThreeWToolkit/models/mlp.py
+++ b/toolkit/ThreeWToolkit/models/mlp.py
@@ -2,12 +2,15 @@ import numpy as np
 import torch.nn as nn
 import torch
 from torch.utils.data import DataLoader
+import logging
 
 from tqdm.auto import tqdm
 from ..core.base_models import ModelsConfig, BaseModels
 from ..core.enums import ModelTypeEnum, ActivationFunctionEnum
 from typing import Iterable, TypeAlias, Callable
 from pydantic import Field, field_validator
+
+logger = logging.getLogger(__name__)
 
 # Type alias for PyTorch model parameters
 ParamsT: TypeAlias = (
@@ -571,9 +574,22 @@ class MLP(BaseModels, nn.Module):
                 pbar.set_description_str(
                     f"[Pipeline] Training | train_loss: {avg_epoch_train_loss:.4f}, val_loss: {val_loss:.4f}"
                 )
+                logger.info(
+                    "Epoch %d/%d | train_loss=%.6f | val_loss=%.6f",
+                    epoch_idx + 1,
+                    epochs,
+                    avg_epoch_train_loss,
+                    val_loss,
+                )
             else:
                 pbar.set_description_str(
                     f"[Pipeline] Training | train_loss: {avg_epoch_train_loss:.4f}"
+                )
+                logger.info(
+                    "Epoch %d/%d | train_loss=%.6f",
+                    epoch_idx + 1,
+                    epochs,
+                    avg_epoch_train_loss,
                 )
 
         return loss_dict

--- a/toolkit/ThreeWToolkit/trainer/trainer.py
+++ b/toolkit/ThreeWToolkit/trainer/trainer.py
@@ -3,6 +3,8 @@ import torch.nn as nn
 import torch.optim as optim
 import pandas as pd
 import numpy as np
+import logging
+logger = logging.getLogger(__name__)
 
 from pathlib import Path
 from typing import Callable, Union
@@ -354,6 +356,16 @@ class ModelTrainer(
         self.shuffle_train = config.shuffle_train
         self.history: list = []
 
+        logger.info(
+            "ModelTrainer initialized | model=%s | device=%s | lr=%s | epochs=%d | batch=%d | cv=%s",
+            type(self.model).__name__,
+            self.device,
+            self.lr,
+            self.epochs,
+            self.batch_size,
+            bool(self.cross_validation),
+        )
+
     def pre_process(
         self, data: dict | tuple | list
     ) -> dict[str, pd.DataFrame | pd.Series | dict | None]:
@@ -426,8 +438,13 @@ class ModelTrainer(
         else:
             kwargs = kwargs_value
 
+        logger.info("Training started")
+        
         # Perform training
         self.train(x_train, y_train, x_val, y_val, **kwargs)
+
+        logger.info("Training finished | history_len=%d", len(self.history))
+
 
         # Add training results to data
         data["model"] = self.model
@@ -617,6 +634,7 @@ class ModelTrainer(
             or a single-element list (regular training)
         """
         if self.cross_validation:
+            logger.info("Cross-validation enabled | n_splits=%d", self.n_splits)
             self.history = []
 
             # Create stratified k-fold splits
@@ -637,6 +655,7 @@ class ModelTrainer(
                 colour="#0a2c53",
             )
             for fold, (train_idx, val_idx) in pbar:
+                logger.info("Fold %d/%d started", fold + 1, self.n_splits)
                 # Updates the bar description for the current fold
                 pbar.set_description_str(f"[Pipeline] Training Fold {fold + 1}")
 
@@ -663,6 +682,7 @@ class ModelTrainer(
                 self.history.append(fold_history)
 
         elif x_val is not None and y_val is not None:
+            logger.info("Using provided validation set")
             # Use provided validation data
             self.history = [
                 self.call_trainer(x_train, y_train, x_val=x_val, y_val=y_val, **kwargs)
@@ -788,6 +808,7 @@ class ModelTrainer(
             The saved model can be loaded later using the load() method.
         """
         ModelRecorder.save_best_model(model=self.model, filename=filepath)
+        logger.info("Saving model to %s", filepath)
 
     def load(self, filepath: Path) -> MLP | SklearnModels:
         """Load a previously saved model from disk.
@@ -809,6 +830,7 @@ class ModelTrainer(
         state_dict = ModelRecorder.load_model(filename=filepath)
         if isinstance(self.model, MLP):
             self.model.load_state_dict(state_dict)
+        logger.info("Loading model from %s", filepath)
         return self.model
 
     def assess(
@@ -861,6 +883,12 @@ class ModelTrainer(
                     else TaskTypeEnum.REGRESSION
                 ),
             )
+
+        logger.debug(
+            "Assessment config | metrics=%s | task_type=%s",
+            assessment_config.metrics,
+            assessment_config.task_type,
+        )
 
         assessor = ModelAssessment(assessment_config)
         assessor._setup_metrics()

--- a/toolkit/ThreeWToolkit/trainer/trainer.py
+++ b/toolkit/ThreeWToolkit/trainer/trainer.py
@@ -4,7 +4,6 @@ import torch.optim as optim
 import pandas as pd
 import numpy as np
 import logging
-logger = logging.getLogger(__name__)
 
 from pathlib import Path
 from typing import Callable, Union
@@ -22,6 +21,8 @@ from ..models.sklearn_models import SklearnModelsConfig, SklearnModels
 from ..utils import ModelRecorder
 from torch.utils.data import TensorDataset
 from ..assessment.model_assess import ModelAssessment, ModelAssessmentConfig
+
+logger = logging.getLogger(__name__)
 
 
 class TrainerConfig(ModelTrainerConfig):
@@ -439,12 +440,11 @@ class ModelTrainer(
             kwargs = kwargs_value
 
         logger.info("Training started")
-        
+
         # Perform training
         self.train(x_train, y_train, x_val, y_val, **kwargs)
 
         logger.info("Training finished | history_len=%d", len(self.history))
-
 
         # Add training results to data
         data["model"] = self.model


### PR DESCRIPTION
This PR introduces a structured logging system across the framework to improve observability, debugging, and experiment traceability.

It closes #10 

## ✅ What was added

This PR introduces a basic logging structure to the framework with the following changes:

- A logging directory definition was added to `constants.py`, centralizing where logs should be stored.
- A `logging_config.py` setup file was introduced to configure the logging format, handlers, and automatic file creation.
- The logger setup is automatically executed when the toolkit is imported.
- Loggers (`logging.getLogger(__name__)`) were added to individual modules.

At this stage, logging has been integrated into:

- `trainer/trainer.py`
- `models/mlp.py`

## 📂 How it works

Every time the toolkit runs, a new log file is automatically generated inside the configured `LOGS_DIR`.

Each execution creates a file following the pattern:

```
run_<timestamp>.log
```

Example:

```
run_2026-02-12_18-58-05.log
```

## 🧾 Log Format

Logs follow this structure:

```
<timestamp> | <level> | <module> | <message>
```

Example output:

```
2026-02-12 18:58:05,742 | INFO | ThreeWToolkit.trainer.trainer | ModelTrainer initialized | model=MLP | device=cpu | lr=0.001 | epochs=3 | batch=16 | cv=False
2026-02-12 18:58:05,761 | INFO | ThreeWToolkit.models.mlp | Epoch 1/3 | train_loss=0.860053 | val_loss=0.575064
2026-02-12 18:58:05,765 | INFO | ThreeWToolkit.models.mlp | Epoch 2/3 | train_loss=0.694027 | val_loss=0.531950
2026-02-12 18:58:05,768 | INFO | ThreeWToolkit.models.mlp | Epoch 3/3 | train_loss=0.741854 | val_loss=0.493022
```

The idea is to progressively expand logging coverage across other modules (dataset loading, preprocessing, assessment, etc.), based on reviewer suggestions and future improvements.

----

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
