### PR TITLE
Enable Coveralls integration and add coverage badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Testing
         run: uv run ./bin/test
 
+      - name: Testing with coverage
+        run: |
+          uv run pytest --cov=ThreeWToolkit --cov-report=xml:coverage.xml
+
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2.3.6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Testing
         run: uv run ./bin/test
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Testing
         run: uv run ./bin/test
 
-      - name: Testing with coverage
-        run: |
-          uv run pytest --cov=ThreeWToolkit --cov-report=xml:coverage.xml
-
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2.3.6
         with:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CC BY 4.0][cc-by-shield]][cc-by]
 [![Code style][black-shield]][black]
 [![Versioning][semver-shield]][semver]
+[![Coverage Status][coveralls-shield]][coveralls]
 
 [apache]: https://opensource.org/licenses/Apache-2.0
 [apache-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
@@ -12,6 +13,8 @@
 [black-shield]: https://img.shields.io/badge/code%20style-black-000000.svg
 [semver]: https://semver.org
 [semver-shield]: https://img.shields.io/badge/semver-2.0.0-blue
+[coveralls]: https://coveralls.io/github/rafaelpadilla/3W?branch=dev
+[coveralls-shield]: https://coveralls.io/repos/github/rafaelpadilla/3W/badge.svg?branch=dev
 
 # Table of Content
 

--- a/bin/test
+++ b/bin/test
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -ex
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
-: "${RUN_SLOW_TESTS:=0}"  # If not set, default to 0
+: "${RUN_SLOW_TESTS:=0}"
 echo "RUN_SLOW_TESTS is set to $RUN_SLOW_TESTS"
 
-pytest tests
+pytest tests \
+  --cov=ThreeWToolkit \
+  --cov-report=term \
+  --cov-report=xml:coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "black>=26.1.0",
     "ruff>=0.14.13",
     "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
     "flake8",
     "jupyter",
     "uv",

--- a/toolkit/ThreeWToolkit/README.md
+++ b/toolkit/ThreeWToolkit/README.md
@@ -1,6 +1,7 @@
 [![Apache 2.0][apache-shield]][apache] 
 [![Code style][black-shield]][black]
 [![Versioning][semver-shield]][semver]
+[![Coverage Status][coveralls-shield]][coveralls]
 
 [apache]: https://opensource.org/licenses/Apache-2.0
 [apache-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
@@ -8,6 +9,8 @@
 [black-shield]: https://img.shields.io/badge/code%20style-black-000000.svg
 [semver]: https://semver.org
 [semver-shield]: https://img.shields.io/badge/semver-2.0.1-blue
+[coveralls]: https://coveralls.io/github/rafaelpadilla/3W?branch=dev
+[coveralls-shield]: https://coveralls.io/repos/github/rafaelpadilla/3W/badge.svg?branch=dev
 
 <h1>
   <img src="https://raw.githubusercontent.com/petrobras/3W/main/images/3w_logo.png" width="45" style="vertical-align: middle; margin-right: 10px;" />


### PR DESCRIPTION
## Summary

This PR introduces code coverage reporting using Coveralls and adds a coverage badge to the README.

## Changes

- Integrated Coveralls via GitHub Actions
- Updated the test script to generate a `coverage.xml` report using pytest-cov
- Added Coveralls badge to the README
- Ensured coverage is automatically uploaded during CI runs

## Motivation

This improves visibility into test coverage and helps maintain code quality over time. Coverage results are now:

- Automatically generated during CI
- Uploaded to Coveralls
- Displayed in the repository via badge

## Impact

No changes to core functionality. This only affects CI and documentation.



___
By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
