### PR TITLE
Exclude Jupyter notebooks from mypy and black checks

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -7,18 +7,19 @@ CI="${CI:-true}"
 cd "$(dirname "$0")"/..
 
 LINT="toolkit tests"
+EXCLUDE_IPYNB='\.ipynb$'
 
 # Run mypy for type checking
-mypy ${LINT}
+mypy --exclude "${EXCLUDE_IPYNB}" ${LINT}
 
 if [ "${CI}" = true ]; then
     # In CI, only check code formatting and linting with Ruff
-    black --check ${LINT}
-    ruff check ${LINT} 
-    uv run black --check .
+    black --check --extend-exclude "${EXCLUDE_IPYNB}" ${LINT}
+    ruff check --extend-exclude "${EXCLUDE_IPYNB}" ${LINT}
+    uv run black --check --extend-exclude "${EXCLUDE_IPYNB}" .
 else
     # Locally, automatically fix formatting issues with Ruff
-    black ${LINT}
-    uv run black .
-    ruff check --fix ${LINT}
+    black --extend-exclude "${EXCLUDE_IPYNB}" ${LINT}
+    uv run black --extend-exclude "${EXCLUDE_IPYNB}" .
+    ruff check --fix --extend-exclude "${EXCLUDE_IPYNB}" ${LINT}
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pylatex>=1.4.2",
     "statsmodels>=0.14.5",
     "requests<=2.35.5",
+    "black[jupyter]>=26.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
As we now have a dedicated `nb_test` to test jupyter notebooks, we can now exclude all .ipynb from our `./bin/lint` checks.

---------------------

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
