### PR TITLE
Updating markdown files to new repo structure

### DIFF
--- a/3W_TOOLKIT_STRUCTURE.md
+++ b/3W_TOOLKIT_STRUCTURE.md
@@ -1,10 +1,28 @@
-The 3W Toolkit is a software package written in Python 3 structured in the following sub-modules:
+The 3W Toolkit is a software package written in Python 3 and located in
+the [toolkit](toolkit) directory.
 
-* **base**: groups the objects used by the other sub-modules;
-* **dev**: has all the resources related to development of Machine 
-Learning models;
-* **misc**: brings together diverse resources that do not fit in the 
-other sub-modules;
-* **rolling_window**: creates a view of array which for every point 
-gives the n-dimensional neighbourhood of size window. New dimensions are 
-added at the end of array or after the corresponding original dimension.
+The importable package is [toolkit/ThreeWToolkit](toolkit/ThreeWToolkit)
+and is structured in the following submodules:
+
+* **assessment**: model assessment and assessment visualization resources;
+* **clustering**: clustering algorithms, distances, normalization,
+  resampling, consensus, and quality helpers;
+* **core**: base classes, shared interfaces, enums, and configuration-driven
+  instantiation utilities used by the other submodules;
+* **data_visualization**: plotting and visualization tools for 3W time
+  series and derived analyses;
+* **dataset**: dataset loaders, subsets, transformations, and dataset
+  output abstractions;
+* **feature_extraction**: feature extraction methods and adapters;
+* **metrics**: classification and regression metrics;
+* **models**: model wrappers and model implementations;
+* **preprocessing**: data cleaning, normalization, remapping, imputation,
+  label filling, and related preprocessing steps;
+* **reports**: report-generation utilities and LaTeX assets;
+* **trainer**: framework-specific training orchestration;
+* **utils**: general utilities used across the toolkit.
+
+Toolkit usage examples and demonstration notebooks are located in
+[toolkit/demos](toolkit/demos). Contributions that add or change toolkit
+code, tests, demos, or development workflow should also follow the
+[3W Toolkit contributing guide](3W_TOOLKIT_CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ In this guide we present how you can propose each type of contributions that we 
     * [Levels for contributions](#levels-for-contributions)
     * [3W Dataset's structure](#3w-datasets-structure)
     * [3W Toolkit's structure](#3w-toolkits-structure)
+    * [3W Toolkit's contributing guide](#3w-toolkits-contributing-guide)
     * [Jupyter Notebooks](#jupyter-notebooks)
     * [Executing examples](#executing-examples)
 * [Proposing contributions](#proposing-contributions)
@@ -72,7 +73,7 @@ We expect to receive contributions at different levels, as shown in the figure b
     * You can recommend new specific problems.
 * Level 3:
     * You can develop and propose approaches and algorithms for already incorporated problems;
-    * You can elaborate and send us new overvies;
+    * You can elaborate and send us new overviews;
     * You can idealize, develop and propose new useful tools.
 * Level 4:
     * You can develop and submit us ensemble methods;
@@ -88,20 +89,27 @@ At level 1, the 3W Dataset consists of multiple Parquet files saved in subdirect
 
 ## 3W Toolkit's structure
 
-At level 2, the 3W Toolkit is implemented in sub-modules as discribed [here](3W_TOOLKIT_STRUCTURE.md).
+At level 2, the 3W Toolkit is implemented in sub-modules as described [here](3W_TOOLKIT_STRUCTURE.md).
+
+## 3W Toolkit's contributing guide
+
+If your contribution changes the 3W Toolkit source code, tests, demos, or developer workflow, please also read the [3W Toolkit contributing guide](3W_TOOLKIT_CONTRIBUTING.md). It describes the toolkit architecture, expected extension patterns, testing guidelines, and quality checks for contributions under `3W/toolkit/`, `3W/tests/`, and related toolkit examples.
 
 ## Jupyter Notebooks 
 
 Jupyter Notebooks play an important role in the 3W Project as a way to demonstrate usage, explore datasets, and present complete experimental pipelines. To keep the project organized, please follow this structure:
 
 - **Toolkit demos**  
-  Add notebooks demonstrating how to use the toolkit in: `3W/toolkit/demos/`
+  Add notebooks demonstrating how to use the toolkit in `3W/toolkit/demos/`.
 
 - **Dataset exploration**  
-  Add notebooks for dataset usage and analysis in: `3W/dataset/demos/`
+  Add notebooks for dataset usage, exploratory analyses, and dataset overviews in `3W/dataset/demos/`. When adding a contributor-specific overview, use a dedicated subdirectory such as `3W/dataset/demos/[your_name_here]/main.ipynb`.
 
 - **Benchmarks**  
-  Add complete and independent benchmarking projects in: `3W/benchmarks/`
+  Add complete and independent benchmarking projects in `3W/benchmarks/`.
+
+- **Learning resources and tutorials**
+  Add self-contained educational material, tutorials, and course-style notebooks in `3W/resources/`, preferably under a versioned or topic-specific subdirectory.
 
 - **Technical documents**  
   The `3W/docs/` folder is reserved for academic materials such as papers, theses in `.pdf` format. Do not place notebooks here.
@@ -142,13 +150,13 @@ It is important to keep in mind that all source code is implemented according to
 
 ## New 3W Dataset's overviews
 
-Visualization is one of the most important steps in this type of project. Therefore, you can propose [Jupyter Notebooks](https://jupyter.org/) with different views. For this, submit a **pull request** on a branch called `new_3w_datasets_overviews` with a file named `overviews\[your_name_here]\main.ipynb` that you've developed. If we like your overview, your file could be listed in this repository as a 3W Toolkit's example of use.
+Visualization is one of the most important steps in this type of project. Therefore, you can propose [Jupyter Notebooks](https://jupyter.org/) with different views of the 3W Dataset. For this, submit a **pull request** on a branch called `new_3w_datasets_overviews` with a notebook in `3W/dataset/demos/[your_name_here]/main.ipynb`. If we like your overview, your file could be listed in this repository as a 3W Dataset overview.
 
 ## New approaches and algorithms
 
-Would you like to share in this repository as 3W Toolkit's examples of use approaches and algorithms for already incorporated problems? The procedure for this is to submit a **pull request** on a branch called `new_approaches_and_algorithms` with [Jupyter Notebooks](https://jupyter.org/) that you've developed in the directory corresponding to the chosen problem. 
+Would you like to share approaches and algorithms for already incorporated problems in this repository? The procedure for this is to submit a **pull request** on a branch called `new_approaches_and_algorithms`. Use `3W/toolkit/demos/` for notebooks that demonstrate how to use the 3W Toolkit, `3W/benchmarks/` for complete and independent benchmarking projects, and `3W/resources/` for educational or tutorial material. Contributions that add reusable toolkit code should follow the [3W Toolkit contributing guide](3W_TOOLKIT_CONTRIBUTING.md).
 
-Specific benchmarls will be incorporated into this project gradually. All benchmarks will be included in the folder `3W/benchmarks/`
+Specific benchmarks will be incorporated into this project gradually. All benchmarks will be included in the folder `3W/benchmarks/`.
 
 ## Additional requirements
 


### PR DESCRIPTION
## Summary

This PR updates the repository documentation to reflect the current 3W Toolkit structure.

## Changes

- Updated `CONTRIBUTING.md` to align its internal links and sections with the current project layout.
- Added a dedicated reference to the 3W Toolkit contributing guide.
- Updated notebook/demo references to point to the current toolkit demo location.
- Updated `3W_TOOLKIT_STRUCTURE.md` because it still described old submodules such as `base`, `modeling_window`, and `contributing`.

## Notes

No source code behavior was changed. This PR only updates Markdown documentation.

##

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
